### PR TITLE
feat: AWS-154 support persistent volume and volume mount in Rancher2 + proxyBufferSize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 test.js
+.env-test-secrets
 dist
+.github/workflows/my_test.yml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# Deployment Action
+
+This GitHub Action can be used to deploy APIs and static websites into TFSO. It currently supports deploying to Rancher1, Rancher2 and deploying static files to S3.
+
+## Local development
+
+Developing GH Actions locally used to be an absolute pain, since we had to commit - then test - for every change, often testing in a completely different repository.
+
+Some very nice people have created a way to test GH Actions locally, called [act](https://github.com/nektos/act). Do yourself a huge favor and download the `act` CLI _now_!
+
+### How to develop locally
+
+1. Download [act](https://github.com/nektos/act)
+2. Comment out the `dist` line in the [.gitignore](./.gitignore) file. (annoying I know, but `act` does not find dist if it is in `.gitignore`)
+3. Ensure you have cloned and setup `tfso/deploymentapi` locally. You will likely need to connected to our VPN as well.
+4. Find a repository that has already run a deployment job using `tfso/action-deployment`. Find the step that deploys, expand the **Run tfso/action-deployment@v1** and copy its content.
+5. Create your own action using the content - you can create a file called `my_test.yml` under `.github/workflows`. The file is ignored by git, so have as much fun as you want here.
+    - If you point to secrets in the workflow file, you can create a file called `.env-test-secrets` (also ignored). And tell `act` to look for the secrets file.
+
+In the end you might have a YAML file looking something like this:
+
+``yml
+name: My test
+
+on: push
+
+env:
+jobs:
+  my-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      # MUST HAVE
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: 'deployment-action'
+
+      # MUST HAVE
+      - name: Checkout Github
+        uses: actions/checkout@v2
+        
+      - uses: ./
+        name: deploy
+        with:
+          type: rancher2
+          service_name:  tfso.api.example
+          image_name: tfso/example-api
+          version: v0.0.1
+          dd-service: example.24sevenoffice.com
+          team: "aws"
+          module: "deployment"
+          deployment_token: ${{ secrets.DEPLOYMENT_API_TOKEN }}
+          environment: beta
+          instances: 1
+          container-port: 80
+          http-endpoint: example.api2.24sevenoffice.com
+          healthtest-path: /healthz
+          readytest-path: /healthz
+        env:
+          TFSO_APACHE_SERVER_NAME: payroll-review-114.api2.24sevenoffice.com
+          DEPLOYMENT_URI: https://localhost:3000 # Point to locally running instance of deploymentapi
+          NODE_TLS_REJECT_UNAUTHORIZED: 0 # This is needed when calling local deploymentapi, since it uses a self-signed cert
+````
+
+Not that you must have the first two checkout steps, you also need to set `DEPLOYMENT_URI` and  `NODE_TLS_REJECT_UNAUTHORIZED: 0` if you want to work against a locally running deploymentapi.
+
+The last step:
+
+```sh
+# Remove `--secret-file .env-test-secrets` if no secrets
+# my-deployment is the name of the job you want to run
+act -j my-deployment --secret-file .env-test-secrets
+```
+
+If you get an error with the code `MODULE_NOT_FOUND`, you have probably forgot to comment out `dist` in `.gitignore`.

--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ Some very nice people have created a way to test GH Actions locally, called [act
 
 1. Download [act](https://github.com/nektos/act)
 2. Comment out the `dist` line in the [.gitignore](./.gitignore) file. (annoying I know, but `act` does not find dist if it is in `.gitignore`)
-3. Ensure you have cloned and setup `tfso/deploymentapi` locally. You will likely need to connected to our VPN as well.
+3. Ensure you have cloned and setup `tfso/deploymentapi` locally.
 4. Find a repository that has already run a deployment job using `tfso/action-deployment`. Find the step that deploys, expand the **Run tfso/action-deployment@v1** and copy its content.
 5. Create your own action using the content - you can create a file called `my_test.yml` under `.github/workflows`. The file is ignored by git, so have as much fun as you want here.
     - If you point to secrets in the workflow file, you can create a file called `.env-test-secrets` (also ignored). And tell `act` to look for the secrets file.
 
 In the end you might have a YAML file looking something like this:
 
-``yml
+*.github/workflows/my_test.yml*
+```yml
 name: My test
 
 on: push
@@ -57,10 +58,14 @@ jobs:
           healthtest-path: /healthz
           readytest-path: /healthz
         env:
-          TFSO_APACHE_SERVER_NAME: payroll-review-114.api2.24sevenoffice.com
           DEPLOYMENT_URI: https://localhost:3000 # Point to locally running instance of deploymentapi
           NODE_TLS_REJECT_UNAUTHORIZED: 0 # This is needed when calling local deploymentapi, since it uses a self-signed cert
-````
+```
+
+*.env-test-secrets*
+```
+DEPLOYMENT_API_TOKEN=secret_token
+```
 
 Not that you must have the first two checkout steps, you also need to set `DEPLOYMENT_URI` and  `NODE_TLS_REJECT_UNAUTHORIZED: 0` if you want to work against a locally running deploymentapi.
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: 0 # This is needed when calling local deploymentapi, since it uses a self-signed cert
 ```
 
+Note that you must have the first two checkout steps, you also need to set `DEPLOYMENT_URI` and  `NODE_TLS_REJECT_UNAUTHORIZED: 0` if you want to work against a locally running deploymentapi.
+
+The secrets file is similar to .env files: 
+
 *.env-test-secrets*
 ```
 DEPLOYMENT_API_TOKEN=secret_token
 ```
-
-Not that you must have the first two checkout steps, you also need to set `DEPLOYMENT_URI` and  `NODE_TLS_REJECT_UNAUTHORIZED: 0` if you want to work against a locally running deploymentapi.
 
 The last step:
 

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,15 @@ inputs:
   healthtest-command:
     required: false
     description: 'Commands that will be run - test if commands exit with exit code 0 '
-
+  persistent-volumes:
+    required: false
+    description: 'Setup a persistent volume for the deployment, must be a multi line string with objects'
+  volume-mounts:
+    required: false
+    description: 'Config for mounting volumes to a container in Rancher2, must be a multi line string with objects'
+  proxy-buffer-size:
+    required: false
+    description: 'Max buffer size of the nginx controller ingress (Rancher2)'
   readytest-initialdelay:
     required: false
     description: 'Delay in seconds before initial readiness probing'

--- a/src/apiService.ts
+++ b/src/apiService.ts
@@ -64,7 +64,9 @@ export const deploy = async (authToken: string, deployment: Deployment) => {
     livenessProbe: deployment.livenessProbe,
     instances: deployment.instances,
     imageName: deployment.imageName,
-    deployerName: deployment.deployerName
+    deployerName: deployment.deployerName,
+    volumes: deployment.volumes,
+    volumeMounts: deployment.volumeMounts
   },null,2);  
   console.log("POST BODY",params);
   const response = await fetch(`${deployment.uri}/${deployment.type}`, {

--- a/src/apiService.ts
+++ b/src/apiService.ts
@@ -66,7 +66,8 @@ export const deploy = async (authToken: string, deployment: Deployment) => {
     imageName: deployment.imageName,
     deployerName: deployment.deployerName,
     volumes: deployment.volumes,
-    volumeMounts: deployment.volumeMounts
+    volumeMounts: deployment.volumeMounts,
+    proxyBufferSize: deployment.proxyBufferSize,
   },null,2);  
   console.log("POST BODY",params);
   const response = await fetch(`${deployment.uri}/${deployment.type}`, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,10 +60,11 @@ const run = async () => {
   const envVariables = Object.keys(process.env || {}).filter(x=>x.indexOf("TFSO_")==0).reduce((prev:{[name:string]:string},cur:string)=>{ prev[cur.replace('TFSO_','')] = process.env[cur]; return prev } ,{})
   const containerPortString = core.getInput('container-port');
   const httpEndpoint = core.getInput('http-endpoint');
+  const proxyBufferSize = core.getInput("proxy-buffer-size")
   const readinessProbe = getProbeConfiguration(core, 'readytest')
   const livenessProbe = getProbeConfiguration(core, 'healthtest')
-  const volumes = getVolumeConfig(core.getMultilineInput('persistentVolumes'), 'persistentVolumeClaim')
-  const volumeMounts = core.getMultilineInput('volumeMounts').map(v => JSON.parse(v) as VolumeMountConfig)
+  const volumes = getVolumeConfig(core.getMultilineInput('persistent-volumes'), 'persistentVolumeClaim')
+  const volumeMounts = core.getMultilineInput('volume-mounts').map(v => JSON.parse(v) as VolumeMountConfig)
   const branch =
     context.ref.replace("refs/heads/", "") ||
     context.ref.replace("refs/tags/", "");
@@ -93,7 +94,8 @@ const run = async () => {
     dd_service: core.getInput('dd-service'),
     instances: parseInt(core.getInput('instances')),
     imageName,
-    deployerName: deployerName
+    deployerName: deployerName,
+    proxyBufferSize,
 
   };
   console.log(JSON.stringify(deployParams));

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export type Deployment = {
     readinessProbe: ProbeConfig,
     livenessProbe: ProbeConfig,
     volumes: VolumeConfig[]
-    volumeMounts: ContainerVolumeMountConfig[]
+    volumeMounts: VolumeMountConfig[]
     dd_service: string
     team: string
     module: string
@@ -46,4 +46,5 @@ export type Deployment = {
     containerPort: number
     environmentVariables: {[name:string]:string}
     deployerName: string
+    proxyBufferSize: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,25 @@ export type ProbeConfig = {
     command?: string[]
 }
 
+export type PersistentVolumeClaimConfig = {
+    volumeType: 'persistentVolumeClaim'
+    readOnly: boolean
+    claimName: string
+}
+
+export type VolumeConfig = {
+    name: string
+    volume: PersistentVolumeClaimConfig
+}
+
+export type VolumeMountConfig = {
+    readOnly: boolean
+    path: string
+    subPath?: string
+    name: string
+}
+
+
 export type Deployment = {
     env: string
     serviceName: string
@@ -18,6 +37,8 @@ export type Deployment = {
     instances: number
     readinessProbe: ProbeConfig,
     livenessProbe: ProbeConfig,
+    volumes: VolumeConfig[]
+    volumeMounts: ContainerVolumeMountConfig[]
     dd_service: string
     team: string
     module: string


### PR DESCRIPTION
- Implements new features in deploymentapi for mounting volumes in Rancher 2 containers -> https://github.com/tfso/deploymentapi/pull/30.
- Also adds proxyBufferSize since it is missing from the deployment action.
- Added README with info on how to develop locally (you're very much welcome)

I force volumeMounts and persistentVolumes to be multiLine objects, this felt like the best way to handle it to support arrays. Will look like this in the workflow file:
```yml
with:
  persistent-volumes: |
    { "name": "vol-k3eon", "claimName": "pvc-payroll-dev", "readOnly": false }
    { "name": "vol-else", "claimName": "pvc-payroll-dev", "readOnly": true }
  volume-mounts: |
    { "name": "vol-k3eon", "path": "/mnt", "readOnly": false }
    { "name": "vol-else", "path": "/mnt/read", "readOnly": true }
  proxy-buffer-size: 8k
```