### PR TITLE
ci: update build-and-tag-action to support multiple files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Install deps and build
         run: npm ci && npm run build
       
-      # Compile dist/index.js and bundle with action.yml
+      # Compile main/files from package.json and bundle with action.yml
       # Force push major and minor tags, e.g. v1, v1.0
       # See documentation: https://github.com/JasonEtco/build-and-tag-action
-      - uses: JasonEtco/build-and-tag-action@v2
+      - uses: OysteinVesth/build-and-tag-action@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
     "name": "@tfso/action-deployment",
     "version": "1.0.0",
     "description": "",
-    "main": "dist/index.js",
+    "main": "dist/deploy/index.js",
+    "files": [
+        "dist/delete/index.js",
+        "delete/action.yml"
+    ],
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
         "build": "concurrently --kill-others \"npm run build:deploy\" \"npm run build:delete\"",


### PR DESCRIPTION
Forked build-and-tag-action to my own account, hopefully the main repo will be further maintained so we can change back. If not I'll be personally responsible for any future bugs.