### PR TITLE
extending deployment timeout from 2 min to 3min and 30 sec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ const run = async () => {
     location,
     " for latest status on deployment"
   );
-  for (var x = 0; x < 15; x++) {
+  for (var x = 0; x < 20; x++) {
     console.log("Waiting ", x, "seconds - and then testing status");
     await sleep((x + 1) * 1000);
     const status = await checkStatus(token, location);


### PR DESCRIPTION
old:
1+2+3+4+5+6+7+8+9+10+11+12+13+14+15 = 120 s = 2 min
new:
1+2+3+4+5+6+7+8+9+10+11+12+13+14+15+16+17+18+19+20 = 210 s = 3 min 30 sec

Kjedelig når deploymenten kommer halvveis slik som her:
![image](https://github.com/tfso/action-deployment/assets/1505838/4afff35d-6c4e-454f-bfc0-036b4111de4d)

https://github.com/tfso/api-bank-ledger-reconciliation/actions/runs/8070801291/job/22049029779
 - her ble første service (api) deployet (til slutt) selv om det ikke så slik ut github loggen
 - service to (worker) ble aldri forsøkt deployet pga feil i første

... altså var worker og api ute av sync med forskjellige versjonsnummer. Det er jo dumt, og kan kanskje ungåes ved en lenger timeout
