### PR TITLE
fix: AWS-270 Will set readiness/liveness probe or http-endpoint to undefined if not set

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,8 +42,7 @@ inputs:
     default: 'false'
   healthtest-path:
     required: false
-    description: 'Path to health test for container'
-    default: '/health'
+    description: 'Path to health test for container (~ or empty string will ignore path)'
   healthtest-timeout:
     required: false
     description: 'Timeout after failing test - in seconds'
@@ -55,8 +54,7 @@ inputs:
     description: 'Time in seconds between each test'
   readytest-path:
     required: false
-    description: 'Path to ready test for container'
-    default: '/ready'
+    description: 'Path to ready test for container (~ or empty string will ignore path)'
   readytest-command:
     required: false
     description: 'Commands that will be run - test if commands exit with exit code 0 '

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,6 @@ const run = async () => {
   const proxyBufferSize = core.getInput("proxy-buffer-size");
   const readinessProbe = getProbeConfiguration(core, "readytest");
   const livenessProbe = getProbeConfiguration(core, "healthtest");
-  console.log("THEM PROBES:", readinessProbe, livenessProbe);
   const volumes = getVolumeConfig(
     core.getMultilineInput("persistent-volumes"),
     "persistentVolumeClaim"

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,18 @@ const getProbeConfiguration = (core: any, probeType: string): ProbeConfig => {
   const period = core.getInput(`${probeType}-period`);
   const initialdelay = core.getInput(`${probeType}-initialdelay`);
   const timeout = core.getInput(`${probeType}-timeout`);
+
+  const path = core.getInput(`${probeType}-path`) || undefined;
+  const command = core.getInput(`${probeType}-command`)
+    ? [core.getInput(`${probeType}-command`)]
+    : undefined;
+  if (!path && !command) {
+    return undefined;
+  }
+
   return {
-    path: core.getInput(`${probeType}-path`) || undefined,
-    command: core.getInput(`${probeType}-command`)
-      ? [core.getInput(`${probeType}-command`)]
-      : undefined,
+    path,
+    command,
     periodSeconds: period ? parseInt(period) : undefined,
     initialDelaySeconds: initialdelay ? parseInt(initialdelay) : undefined,
     timeoutSeconds: timeout ? parseInt(timeout) : undefined,
@@ -65,10 +72,11 @@ const run = async () => {
   const isReleaseChannel = core.getBooleanInput("release-channel");
   const envVariables = getEnvironmentVariables(process.env);
   const containerPortString = core.getInput("container-port");
-  const httpEndpoint = core.getInput("http-endpoint");
+  const httpEndpoint = core.getInput("http-endpoint") || undefined;
   const proxyBufferSize = core.getInput("proxy-buffer-size");
   const readinessProbe = getProbeConfiguration(core, "readytest");
   const livenessProbe = getProbeConfiguration(core, "healthtest");
+  console.log("THEM PROBES:", readinessProbe, livenessProbe);
   const volumes = getVolumeConfig(
     core.getMultilineInput("persistent-volumes"),
     "persistentVolumeClaim"
@@ -115,7 +123,16 @@ const run = async () => {
     resources,
   };
   console.log(JSON.stringify(deployParams));
-  var location = await deploy(token, { ...deployParams, secrets });
+
+  try {
+    const location = await deploy(token, { ...deployParams, secrets });
+    await waitForDeploymentToComplete(location, token);
+  } catch (error) {
+    core.setFailed(error)
+  }
+};
+
+async function waitForDeploymentToComplete(location: string, token: string): Promise<void> {
   core.setOutput("deploymenturl", location);
   if (!location) {
     console.log("No location returned.  Assume the deployment is ok!");
@@ -138,7 +155,7 @@ const run = async () => {
     }
   }
   throw "Error : Deployment was not set to active within set period.";
-};
+}
 
 function getResourceSettings(c: typeof core) {
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,8 +47,8 @@ export type Deployment = {
   branch?: string;
   imageName?: string;
   instances: number;
-  readinessProbe: ProbeConfig;
-  livenessProbe: ProbeConfig;
+  readinessProbe?: ProbeConfig;
+  livenessProbe?: ProbeConfig;
   volumes: VolumeConfig[];
   volumeMounts: VolumeMountConfig[];
   dd_service: string;


### PR DESCRIPTION
- `~` or empty string as  live/ready path should ignore liveness/readiness probe
- Unspecified http-endpoint will lead to undefined, not empty string
- **additional fix**: Errors from the API will now be more clear, and not hidden inside async exception error i GH Actions
- https://github.com/tfso/api-deployment/pull/69 **must** be merged for this to work

Jira issue: [AWS-270](https://24so.atlassian.net/browse/AWS-270)

[AWS-270]: https://24so.atlassian.net/browse/AWS-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ