### PR TITLE
feat: AWS-318 Adds ability to set cors-allowed-origins deployment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,9 @@ inputs:
   cpu-reservation:
     required: false
     description: "CPU (mCPU) reservation for the container (min cpu)"
+  cors-allowed-origins:
+    required: false
+    description: "Comma separated list of allowed cross-origin URLs"
     
 runs:
   using: 'node16'

--- a/src/apiService.ts
+++ b/src/apiService.ts
@@ -91,7 +91,8 @@ export const deploy = async (authToken: string, deployment: Deployment) => {
       proxyBufferSize: deployment.proxyBufferSize,
       proxyBodySize: deployment.proxyBodySize,
       secrets: deployment.secrets,
-      resources: deployment.resources
+      resources: deployment.resources,
+      corsSettings: deployment.corsSettings,
     },
     null,
     2

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,11 @@ export type Deployment = {
   proxyBufferSize: string;
   proxyBodySize: string;
   resources: Resources;
+  corsSettings: CorsSettings;
+};
+
+export type CorsSettings = {
+  allowedOrigins: string;
 };
 
 export type FetchResponse = { json: () => Promise<any>; status: number };


### PR DESCRIPTION
Uses ability to set CORS allowed origins on deployment. 
https://github.com/tfso/api-deployment/pull/88